### PR TITLE
Refactored replacing clipboard contents into a util function

### DIFF
--- a/app/plugins/copy-url/index.js
+++ b/app/plugins/copy-url/index.js
@@ -1,4 +1,5 @@
 const browser = require('webextension-polyfill')
+const { copyToClipboard } = require('../../util');
 const plugin = {
   keyword: "Copy URL",
   subtitle: 'Copy the URL of the current page.',
@@ -12,13 +13,9 @@ async function copyUrl() {
   const tabs = await browser.tabs.query({active: true, currentWindow: true})
   const activeTabUrl = tabs[0].url
 
-  document.addEventListener('copy', (event) => {
-    event.preventDefault() //this doesn't work w/o this. Investigate why for exploration's sake?
-    const text = activeTabUrl
-    event.clipboardData.setData('text/plain', text)
-  }, {once: true})
-  document.execCommand('copy')
-  window.close()
+  copyToClipboard(activeTabUrl, ev => {
+    window.close();
+  });
 }
 
 module.exports = plugin

--- a/app/util.js
+++ b/app/util.js
@@ -212,6 +212,14 @@ utils.useAvalableExtensionIcon = function useAvalableExtensionIcon(extension) {
   return icon.url
 }
 
-
+utils.copyToClipboard = function copyToClipboard(value, cb) {
+  document.addEventListener('copy', (event) => {
+      event.preventDefault(); // Prevents the default behavior of copying, ex: pressing Ctrl+C
+      // If we didn't prevent the prevent default, the clipboard would be filled with what ever the user had highlighted on the page.
+      event.clipboardData.setData('text/plain', value);
+      cb(event);
+  }, { once: true })
+  document.execCommand('copy');  
+}
 
 module.exports = utils

--- a/app/util.js
+++ b/app/util.js
@@ -209,7 +209,7 @@ utils.useAvalableExtensionIcon = function useAvalableExtensionIcon(extension) {
   return icon.url
 }
 
-utils.copyToClipboard = function copyToClipboard(value, cb) {
+utils.copyToClipboard = function copyToClipboard(value, cb = function() {} ) {
   document.addEventListener('copy', (event) => {
       event.preventDefault(); // Prevents the default behavior of copying, ex: pressing Ctrl+C
       // If we didn't prevent the prevent default, the clipboard would be filled with what ever the user had highlighted on the page.

--- a/app/util.js
+++ b/app/util.js
@@ -67,12 +67,9 @@ utils.displayPotentialMathResult = function(query) {
       keyword: mathResult,
       subtitle: 'Copy number to your clipboard.',
       action: function copyResult() {
-        document.addEventListener('copy', (event) => {
-          event.preventDefault()
-          event.clipboardData.setData('text/plain', mathResult)
-        }, {once: true})
-        document.execCommand('copy')
-        window.close()
+        utils.copyToClipboard(mathResult, ev => {
+          window.close();
+        });
       },
       icon: {
         path: 'images/calculator-icon.svg'


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions 
   * Since no testing environment has be established, establishing one in this pr would be out of scope.

### Description of the Change

As requested in my [previous pr](https://github.com/cliffordfajardo/cato/pull/9), I've extracted the clipboard refactoring into its own pr.
The refactoring adds a function called `copyToClipboard` in util.js on the utils object. I then tried to find all occurrences of clipboard manipulation in the code and changed them to use `copyToClipboard` instead.

### Alternate Designs

We could have opted to use a known and tested clipboard library such as [clipboard.js](https://clipboardjs.com/).

### Why Should This Be In Core?

This pr eliminates some code duplication and centralizes util functions to the util.js file.

### Benefits

This pr eliminates some code duplication and centralizes util functions to the util.js file.

### Possible Drawbacks

Tighter coupling between plugins and core application, since some plugins now will use functions from the core libraries utils.

### Applicable Issues

Old pr: https://github.com/cliffordfajardo/cato/pull/9
 