### PR TITLE
Added "Shorten URL" command

### DIFF
--- a/app/images/shortened-url-icon.svg
+++ b/app/images/shortened-url-icon.svg
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="iso-8859-1"?>
+<!-- Generator: Adobe Illustrator 19.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 472 472" style="enable-background:new 0 0 472 472;" xml:space="preserve">
+<path style="fill:#34495E;" d="M0,4v96h472c0-31.504,0-96,0-96H0z"/>
+<path style="fill:#66CEDB;" d="M320,36l-48,64H0v368h472c0,0,0-247.232,0-368V36H320z"/>
+<path style="fill:#E74C3C;" d="M48,76c-13.232,0-24-10.768-24-24s10.768-24,24-24s24,10.768,24,24S61.232,76,48,76z M48,44
+	c-4.416,0-8,3.592-8,8s3.584,8,8,8s8-3.592,8-8S52.416,44,48,44z"/>
+<path style="fill:#F6BF58;" d="M112,76c-13.232,0-24-10.768-24-24s10.768-24,24-24s24,10.768,24,24S125.232,76,112,76z M112,44
+	c-4.416,0-8,3.592-8,8s3.584,8,8,8s8-3.592,8-8S116.416,44,112,44z"/>
+<path style="fill:#66CEDB;" d="M176,76c-13.232,0-24-10.768-24-24s10.768-24,24-24s24,10.768,24,24S189.232,76,176,76z M176,44
+	c-4.416,0-8,3.592-8,8s3.584,8,8,8s8-3.592,8-8S180.416,44,176,44z"/>
+<g>
+	<polygon style="fill:#00BFC8;" points="41.344,224.44 22.384,196 41.344,167.56 54.656,176.44 41.616,196 54.656,215.56 	"/>
+	<polygon style="fill:#00BFC8;" points="86.656,224.44 73.344,215.56 86.384,196 73.344,176.44 86.656,167.56 105.616,196 	"/>
+</g>
+<rect x="144" y="140" style="fill:#FFFFFF;" width="328" height="112"/>
+<g>
+	<path style="fill:#E74C3C;" d="M192,212c-13.232,0-24-10.768-24-24s10.768-24,24-24s24,10.768,24,24S205.232,212,192,212z M192,180
+		c-4.416,0-8,3.592-8,8s3.584,8,8,8s8-3.592,8-8S196.416,180,192,180z"/>
+	
+		<rect x="207.999" y="200.687" transform="matrix(-0.7071 0.7071 -0.7071 -0.7071 518.6398 209.1708)" style="fill:#E74C3C;" width="16" height="22.624"/>
+</g>
+<rect x="248" y="164" style="fill:#34495E;" width="16" height="64"/>
+<g>
+	<polygon style="fill:#FFFFFF;" points="328,364 304.04,284.896 376,324 344,332 	"/>
+	
+		<rect x="355.99" y="323.713" transform="matrix(-0.7071 0.7071 -0.7071 -0.7071 870.2668 343.5092)" style="fill:#FFFFFF;" width="16" height="56.559"/>
+</g>
+<g>
+	<rect x="32" y="292" style="fill:#00BFC8;" width="16" height="16"/>
+	<rect x="64" y="292" style="fill:#00BFC8;" width="16" height="16"/>
+	<rect x="96" y="292" style="fill:#00BFC8;" width="16" height="16"/>
+	<rect x="32" y="324" style="fill:#00BFC8;" width="16" height="16"/>
+	<rect x="64" y="324" style="fill:#00BFC8;" width="16" height="16"/>
+	<rect x="96" y="324" style="fill:#00BFC8;" width="16" height="16"/>
+	<rect x="128" y="292" style="fill:#00BFC8;" width="16" height="16"/>
+	<rect x="160" y="292" style="fill:#00BFC8;" width="16" height="16"/>
+	<rect x="192" y="292" style="fill:#00BFC8;" width="16" height="16"/>
+	<rect x="128" y="324" style="fill:#00BFC8;" width="16" height="16"/>
+	<rect x="160" y="324" style="fill:#00BFC8;" width="16" height="16"/>
+	<rect x="192" y="324" style="fill:#00BFC8;" width="16" height="16"/>
+</g>
+<g>
+</g>
+<g>
+</g>
+<g>
+</g>
+<g>
+</g>
+<g>
+</g>
+<g>
+</g>
+<g>
+</g>
+<g>
+</g>
+<g>
+</g>
+<g>
+</g>
+<g>
+</g>
+<g>
+</g>
+<g>
+</g>
+<g>
+</g>
+<g>
+</g>
+</svg>

--- a/app/plugins/copy-url/index.js
+++ b/app/plugins/copy-url/index.js
@@ -1,4 +1,5 @@
 const browser = require('webextension-polyfill')
+const { copyToClipboard } = require('../../util');
 const plugin = {
   keyword: "Copy URL",
   subtitle: 'Copy the URL of the current page.',
@@ -12,13 +13,9 @@ async function copyUrl() {
   const tabs = await browser.tabs.query({active: true, currentWindow: true})
   const activeTabUrl = tabs[0].url
 
-  document.addEventListener('copy', (event) => {
-    event.preventDefault() //this doesn't work w/o this. Investigate why for exploration's sake?
-    const text = activeTabUrl
-    event.clipboardData.setData('text/plain', text)
-  }, {once: true})
-  document.execCommand('copy')
-  window.close()
+  copyToClipboard(activeTabUrl, ev => {
+    window.close();
+  });
 }
 
 module.exports = plugin

--- a/app/plugins/shorten-url/index.js
+++ b/app/plugins/shorten-url/index.js
@@ -17,38 +17,50 @@ async function shortenUrl() {
   const postUrl = 'https://www.googleapis.com/urlshortener/v1/url?key=AIzaSyAMSEYpKsnx7pK1I-oKYX7UMC2wumDDjk8'; // Free key allows for 1,000,000 requests per day
   
   const request = new Request(postUrl, {
-    'method': 'POST',
-    'body': JSON.stringify({longUrl: activeTabUrl}),
-    'mode': 'cors',
-    'headers': new Headers({'Content-Type': 'application/json'})
-  })
-  
-  const data = await (await fetch(request)).json();
-  const suggestion = null;
-  if (data.id) {
-    suggestion = {
-        keyword: `${data.id}`,
-        subtitle: 'Copy shortened url to your clipboard.',
-        action: () => {
-          copyToClipboard(data.id, ev => {
-              window.close();
-          });
-        },
-        icon: {
-          path: plugin.icon.path
-        }
-      }
-  } else {
-    suggestion = {
-        keyword: "Sorry, we couldn't shorten your URL at this time.",
-        action: 'The network must be down or our API limit has exceeded.',
-        subtitle: 'Please try again later.',
-        icon: {
-          path: plugin.icon.path
-        }
-      }
+    method: 'POST',
+    body: JSON.stringify({longUrl: activeTabUrl}),
+    mode: 'cors',
+    headers: new Headers({'Content-Type': 'application/json'})
+  });
+
+  //clear suggestions display a temporary suggestion while we wait for a response
+  const temporarySuggestion = {
+    keyword: "Attempting to shorten url.",
+    subtitle: '...',
+    icon: plugin.icon
   }
-  renderSuggestions([suggestion]);
+  window.searchResultsList.innerHTML = ''
+  window.currentSearchSuggestions = [temporarySuggestion]
+  renderSuggestions(window.currentSearchSuggestions)
+  
+  let data = null;
+  let suggestion = null;
+  try {
+    data =  await (await fetch(request)).json();
+    if (!data.id) throw new Error('Property ID not found on response object');
+    suggestion = {
+      keyword: `${data.id}`,
+      subtitle: 'Copy shortened url to your clipboard.',
+      action: () => {
+        copyToClipboard(data.id, ev => {
+            window.close();
+        });
+      },
+      icon: plugin.icon
+    };
+  } catch (e) {
+    data = {
+      id: activeTabUrl
+    };
+    suggestion = {
+      keyword: "Sorry, we couldn't shorten your URL at this time.",
+      subtitle: 'Either this page is not available online, or the API limit has been exceeded.',
+      icon: plugin.icon
+    };
+  }
+  window.searchResultsList.innerHTML = ''
+  window.currentSearchSuggestions = [suggestion]
+  renderSuggestions(window.currentSearchSuggestions)
 }
 
 module.exports = plugin;

--- a/app/plugins/shorten-url/index.js
+++ b/app/plugins/shorten-url/index.js
@@ -1,0 +1,54 @@
+const browser = require('webextension-polyfill');
+const {copyToClipboard, renderSuggestions} = require('../../util');
+
+const iconUrl = 'images/shortened-url-icon.svg';
+
+module.exports = {
+  keyword: "Shorten URL",
+  subtitle: 'Shorten the current url.',
+  action: shortenUrl,
+  icon: {
+    path: iconUrl
+  }
+};
+
+async function shortenUrl() {
+  const tabs = await browser.tabs.query({active: true,currentWindow: true});
+
+  const activeTabUrl = tabs[0].url;
+  const postUrl = 'https://www.googleapis.com/urlshortener/v1/url?key=AIzaSyAMSEYpKsnx7pK1I-oKYX7UMC2wumDDjk8'; // Free key allows for 1,000,000 requests per day
+  
+  const request = new Request(postUrl, {
+    'method': 'POST',
+    'body': JSON.stringify({longUrl: activeTabUrl}),
+    'mode': 'cors',
+    'headers': new Headers({'Content-Type': 'application/json'})
+  })
+  
+  const data = await (await fetch(request)).json();
+  const suggestion = null;
+  if (data.id) {
+    suggestion = {
+        keyword: `${data.id}`,
+        subtitle: 'Copy shortened url to your clipboard.',
+        action: () => {
+          copyToClipboard(data.id, ev => {
+              window.close();
+          });
+        },
+        icon: {
+          path: iconUrl
+        }
+      }
+  } else {
+    suggestion = {
+        keyword: "Sorry, we couldn't shorten your URL at this time.",
+        action: 'The network must be down or our API limit has exceeded.',
+        subtitle: 'Please try again later.',
+        icon: {
+          path: iconUrl
+        }
+      }
+  }
+  renderSuggestions([suggestion]);
+}

--- a/app/plugins/shorten-url/index.js
+++ b/app/plugins/shorten-url/index.js
@@ -1,14 +1,12 @@
 const browser = require('webextension-polyfill');
 const {copyToClipboard, renderSuggestions} = require('../../util');
 
-const iconUrl = 'images/shortened-url-icon.svg';
-
-module.exports = {
+const plugin = {
   keyword: "Shorten URL",
   subtitle: 'Shorten the current url.',
   action: shortenUrl,
   icon: {
-    path: iconUrl
+    path: 'images/shortened-url-icon.svg'
   }
 };
 
@@ -37,7 +35,7 @@ async function shortenUrl() {
           });
         },
         icon: {
-          path: iconUrl
+          path: plugin.icon.path
         }
       }
   } else {
@@ -46,9 +44,11 @@ async function shortenUrl() {
         action: 'The network must be down or our API limit has exceeded.',
         subtitle: 'Please try again later.',
         icon: {
-          path: iconUrl
+          path: plugin.icon.path
         }
       }
   }
   renderSuggestions([suggestion]);
 }
+
+module.exports = plugin;

--- a/app/util.js
+++ b/app/util.js
@@ -212,6 +212,14 @@ utils.useAvalableExtensionIcon = function useAvalableExtensionIcon(extension) {
   return icon.url
 }
 
-
+utils.copyToClipboard = function copyToClipboard(value, cb) {
+  document.addEventListener('copy', (event) => {
+      event.preventDefault(); // Prevents the default behavior of copying, ex: pressing Ctrl+C
+      // If we didn't prevent the prevent default, the clipboard would be filled with what ever the user had highlighted on the page.
+      event.clipboardData.setData('text/plain', value);
+      cb(event);
+  }, { once: true })
+  document.execCommand('copy');  
+}
 
 module.exports = utils

--- a/app/util.js
+++ b/app/util.js
@@ -67,12 +67,9 @@ utils.displayPotentialMathResult = function(query) {
       keyword: mathResult,
       subtitle: 'Copy number to your clipboard.',
       action: function copyResult() {
-        document.addEventListener('copy', (event) => {
-          event.preventDefault()
-          event.clipboardData.setData('text/plain', mathResult)
-        }, {once: true})
-        document.execCommand('copy')
-        window.close()
+        utils.copyToClipboard(mathResult, ev => {
+          window.close();
+        });
       },
       icon: {
         path: 'images/calculator-icon.svg'


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions
   * Since no testing environment has be established, establishing one in this pr would be out of scope.
* This pr relies on functionality brought in by https://github.com/cliffordfajardo/cato/pull/13

### Description of the Change

This pr adds a command called "Shorten URL". This command was a feature request by my self in the [fr issue](https://github.com/cliffordfajardo/cato/issues/1) comment sections.
The command uses the [goo.gl](https://goo.gl/) url shorten api, and is ment to be used as a way of easily sharing URL:s without having to worry about how long and ugly some of them can be. As a bonus the google api may provide usage statistics for shortened urls. However this requires 2auth, which isn't part of this pr.

### Alternate Designs

The same feature could have been implemented using a set of other API:s, such as [tinyurl](https://tinyurl.com/) or [bitly](https://bitly.com/).

### Why Should This Be In Core?

Having a command that shortens URL:s to a more handily size is always useful.

### Benefits

Adds a requested feature.

### Possible Drawbacks

Might contribute to command bloat

### Applicable Issues

https://github.com/cliffordfajardo/cato/issues/1
