### PR TITLE
Added "View Source" & "Toggle View Source" command

### DIFF
--- a/app/plugins/view-source-toggle/index.js
+++ b/app/plugins/view-source-toggle/index.js
@@ -1,0 +1,29 @@
+const browser = require('webextension-polyfill')
+const plugin = {
+  keyword: "Toggle View Source",
+  subtitle: 'Toggle between the source and the normal view of the current page',
+  action: toggleViewSource,
+  icon: {
+    path: 'images/chrome-icon.svg'
+  }
+}
+
+async function toggleViewSource() {
+  const tabs = await browser.tabs.query({active: true, currentWindow: true});
+  const activeTabId = 0 + tabs[0].id;
+  const activeTabUrl = tabs[0].url;
+  const viewSourceString = 'view-source:';
+
+  if (!activeTabUrl.startsWith(viewSourceString)) {
+    await browser.tabs.update(activeTabId, {
+        url: viewSourceString+activeTabUrl
+    });
+  } else {
+    await browser.tabs.update(activeTabId, {
+        url: activeTabUrl.substring(viewSourceString.length)
+    });    
+  }
+  window.close();
+}
+
+module.exports = plugin

--- a/app/plugins/view-source/index.js
+++ b/app/plugins/view-source/index.js
@@ -1,0 +1,25 @@
+const browser = require('webextension-polyfill')
+const plugin = {
+  keyword: "View Source",
+  subtitle: 'Shows the source code of the current page',
+  action: viewSource,
+  icon: {
+    path: 'images/chrome-icon.svg'
+  }
+}
+
+async function viewSource() {
+  const tabs = await browser.tabs.query({active: true, currentWindow: true});
+  const activeTabUrl = tabs[0].url;
+  const viewSourceString = 'view-source:';
+
+  if (!activeTabUrl.startsWith(viewSourceString)) {
+      await browser.tabs.create({url: viewSourceString+activeTabUrl});
+  } else {
+      // If this page is a source page, then just clone it.
+      await browser.tabs.create({url: activeTabUrl}); 
+  }
+
+}
+
+module.exports = plugin


### PR DESCRIPTION
### Description of the Change

This pr adds two commands, "View Source" & "Toggle View Source". The "View Source" command was a feature request by the user @AlexisAnzieu in the [fr issue](https://github.com/cliffordfajardo/cato/issues/1) comment sections. The "Toggle View Source" command was added to avoid situations where users might get "stuck" on the source page (stuck in the sense that they couldn't easily get back to the original page using Cato). 

"View Source" creates a new tab with the URL equal to the original URL plus the string `view-source:` injected at the start of the URL. Ex: Using `View Source` while on `google.com` would open a new tab with the URL equal to `view-source:https://www.google.com/`.

"Toggle View Source" updates the current tab to reflect if the command was used on the original page or on the source page. Ex: Using `Toggle View Source` wile on `google.com` would reload the current page with the new URL equal to `view-source:https://www.google.com/`. If you then used `Toggel View Source` again the page would reload with the URL equal to `https://www.google.com/`.

### Alternate Designs

We could have written our own source inspection tool instead of using the chrome keyword `view-source`.

### Why Should This Be In Core?

Having a command that shows / toggles the source of the page could be useful for users inclined to web-development.

### Benefits

Adds a requested feature.

### Possible Drawbacks

Might contribute to command bloat

### Applicable Issues

https://github.com/cliffordfajardo/cato/issues/1
