### PR TITLE
Added "About" command

### DIFF
--- a/app/plugins/open-about/index.js
+++ b/app/plugins/open-about/index.js
@@ -1,7 +1,7 @@
 const browser = require('webextension-polyfill')
 const plugin = {
   keyword: "About",
-  subtitle: 'Open the browser\'s settings page.',
+  subtitle: 'View general information about your browser.',
   action: openSettings,
   icon: {
     path: 'images/chrome-icon.svg'
@@ -9,7 +9,9 @@ const plugin = {
 }
 
 async function openSettings() {
-  await browser.tabs.create({url: "chrome://settings/help"})
+  await browser.tabs.create({
+    url: "chrome://settings/help"
+  });
 }
 
-module.exports = plugin
+module.exports = plugin;

--- a/app/plugins/open-about/index.js
+++ b/app/plugins/open-about/index.js
@@ -1,0 +1,15 @@
+const browser = require('webextension-polyfill')
+const plugin = {
+  keyword: "About",
+  subtitle: 'Open the browser\'s settings page.',
+  action: openSettings,
+  icon: {
+    path: 'images/chrome-icon.svg'
+  }
+}
+
+async function openSettings() {
+  await browser.tabs.create({url: "chrome://settings/help"})
+}
+
+module.exports = plugin


### PR DESCRIPTION
### Description of the Change

This pr adds a command called "About" that opens a new tab with the URL `chrome://settings/help`.

### Why Should This Be In Core?

The `/help` sub-domain is the only path under the `chrome://settings` page that cant be reached from the main settings page by simply scrolling.

### Benefits

Adds a requested feature.

### Possible Drawbacks

Might contribute to command bloat

### Applicable Issues

https://github.com/cliffordfajardo/cato/issues/1
 