### PR TITLE
Add applications launcher

### DIFF
--- a/app/plugins/open-apps/index.js
+++ b/app/plugins/open-apps/index.js
@@ -1,0 +1,16 @@
+const browser = require('webextension-polyfill')
+
+const plugin = {
+  keyword: "Apps",
+  subtitle: 'View your installed browser applications.',
+  action: openApps,
+  icon: {
+    path: 'images/chrome-icon.svg'
+  }
+}
+
+async function openApps() {
+  await browser.tabs.create({url: "chrome://apps"})
+}
+
+module.exports = plugin


### PR DESCRIPTION
### Description of the Change

Add command to open the applications page for the browser in the same way that the extensions page can be opened.

### Alternate Designs

Easier to type "Apps" into the Cato launcher than opening a new tab and typing "chrome://apps"

### Why Should This Be In Core?

It makes sense to have a shortcut to the apps page as well as one to the extensions page

### Benefits

User efficiency

### Possible Drawbacks

User may think they're opening a detail/config page for the Cato extension (believing it is an application)

### Applicable Issues

None
