### PR TITLE
Added command for opening Twitter

### DIFF
--- a/app/plugins/open-twitter/index.js
+++ b/app/plugins/open-twitter/index.js
@@ -1,0 +1,16 @@
+const browser = require('webextension-polyfill')
+
+const plugin = {
+  keyword: "Twitter",
+  subtitle: 'Open Twitter.',
+  action: openTwitter,
+  icon: {
+    path: 'images/twitter-icon.svg'
+  }
+}
+
+async function openTwitter() {
+  await browser.tabs.create({url: "https://twitter.com"})
+}
+
+module.exports = plugin


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change


This pull request adds a command to open Twitter from Cato


### Alternate Designs

None

### Why Should This Be In Core?

Creates a shortcut for Twitter

### Benefits

Makes accessing Twitter easy

### Possible Drawbacks

Might contribute to command bloat
